### PR TITLE
Update the App to work on macOS11

### DIFF
--- a/SendToKodi/Base.lproj/MainMenu.xib
+++ b/SendToKodi/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12120" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12120"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -667,20 +667,21 @@
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="140" y="154"/>
         </menu>
         <window title="SendToKodi" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="335" y="390" width="355" height="72"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="contentRect" x="335" y="390" width="395" height="72"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
             <view key="contentView" id="EiT-Mj-1SZ">
-                <rect key="frame" x="0.0" y="0.0" width="355" height="72"/>
+                <rect key="frame" x="0.0" y="0.0" width="395" height="72"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kkU-Zy-W74">
-                        <rect key="frame" x="18" y="33" width="128" height="17"/>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kkU-Zy-W74">
+                        <rect key="frame" x="25" y="33" width="154" height="17"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Kodi IP/Hostname:" id="Mc1-Iz-azO">
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Kodi IP/Hostname(:port):" id="Mc1-Iz-azO">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -689,12 +690,12 @@
                             <accessibilityConnection property="title" destination="q2W-98-ddp" id="qrn-k2-O3R"/>
                         </connections>
                     </textField>
-                    <textField verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q2W-98-ddp">
-                        <rect key="frame" x="152" y="30" width="183" height="22"/>
+                    <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q2W-98-ddp">
+                        <rect key="frame" x="185" y="30" width="183" height="22"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="M4V-2G-jGi">
                             <font key="font" metaFont="system"/>
-                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                         <connections>
@@ -708,7 +709,7 @@
                     </textField>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="262.5" y="116"/>
+            <point key="canvasLocation" x="332.5" y="18"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="xd4-I6-gqt"/>
     </objects>

--- a/SendToKodi/Utils.swift
+++ b/SendToKodi/Utils.swift
@@ -16,7 +16,7 @@ struct Utils {
         
         let requestData = self.generateRequestDataFromUrl(url)
         
-        let request = NSMutableURLRequest(url: URL(string: "http://\(hostname):8080/jsonrpc")!)
+        let request = NSMutableURLRequest(url: URL(string: "http://\(hostname)/jsonrpc")!)
         request.httpMethod = "POST"
         request.setValue("application/json",         forHTTPHeaderField: "Accept")
         request.setValue("application/json",         forHTTPHeaderField: "Content-Type")

--- a/SendToKodiAction/ShareViewController.swift
+++ b/SendToKodiAction/ShareViewController.swift
@@ -16,16 +16,17 @@ class ShareViewController: NSViewController {
         
         progress.startAnimation(nil)
         
-        let item = self.extensionContext!.inputItems[0] as! NSExtensionItem
-        
-        if let attachments = item.attachments {
-            (attachments.first as! NSItemProvider).loadItem(forTypeIdentifier: kUTTypeURL as String, options: nil, completionHandler: { (item, error) -> Void in
-                self.sendRequestToKodi(item as! URL)
-            })
-        }
-        else {
-            let cancelError = NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError, userInfo: nil)
-            self.extensionContext!.cancelRequest(withError: cancelError)
+        if let item = self.extensionContext?.inputItems.first as? NSExtensionItem {
+            if let attachment = item.attachments?.first,
+               attachment.hasItemConformingToTypeIdentifier("public.url") {
+                attachment.loadObject(ofClass: NSURL.self, completionHandler: {(res, err) in
+                    self.sendRequestToKodi(res as! URL)
+                })
+            }
+            else {
+                let cancelError = NSError(domain: NSCocoaErrorDomain, code: NSUserCancelledError, userInfo: nil)
+                self.extensionContext!.cancelRequest(withError: cancelError)
+            }
         }
     }
     


### PR DESCRIPTION
Trying the release package, I found that the extension in Safari just would not work. The popup never showed up.
In the debugger, I found that newer macOS versions didn't like to work with the `.loadItem(forTypeIdentifier:options:completionHandler:)` API, but switching 
to `loadObject(ofClass:completionHandler:)` I managed to restore functionality on macOS 11.

Additionally, the default port seems to have changed, I'm not sure if this is default behaviour, but users now can input their own ports (optionally) in the settings window.

Tested only on an Intel Mac with macOS 11.